### PR TITLE
Bump Min PHP Version to `8.3`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.3', '8.4']
         dependency-version: [ prefer-stable ]
         parallel: [ '', '--parallel' ]
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.2",
-        "pestphp/pest-plugin": "^3.0"
+        "php": "^8.3",
+        "pestphp/pest-plugin": "^4.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,9 +22,8 @@
         }
     },
     "require-dev": {
-        "faissaloux/pest-plugin-inside": "^1.6",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-dev-tools": "^3.0"
+        "pestphp/pest": "^4.0.0",
+        "pestphp/pest-dev-tools": "^4.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -100,13 +100,6 @@ test('specific language', function () {
         );
 });
 
-test('config files return lowercase and unique values', function () {
-    expect('src/Config')
-        ->toReturnLowercase()
-        ->toReturnUnique()
-        ->toBeOrdered();
-});
-
 test('json output', function () {
     $output = new BufferedOutput;
     $plugin = new class($output) extends Plugin


### PR DESCRIPTION
Bumps the PHP version to 8.3 for Pest 4. Removed `faissaloux/pest-plugin-inside` for now.