### PR TITLE
Add `pest-plugin-inside` Package Back 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         }
     },
     "require-dev": {
+        "faissaloux/pest-plugin-inside": "^1.7",
         "pestphp/pest": "^4.0.0",
         "pestphp/pest-dev-tools": "^4.0.0"
     },

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -100,6 +100,13 @@ test('specific language', function () {
         );
 });
 
+test('config files return lowercase and unique values', function () {
+    expect('src/Config')
+        ->toReturnLowercase()
+        ->toReturnUnique()
+        ->toBeOrdered();
+});
+
 test('json output', function () {
     $output = new BufferedOutput;
     $plugin = new class($output) extends Plugin


### PR DESCRIPTION
To keep config files tidy. Removed in https://github.com/pestphp/pest-plugin-profanity/pull/50 as it didn't support Pest v4. Now it does 🥳 