### PR TITLE
add way to ignore certain lines

### DIFF
--- a/src/ProfanityAnalyser.php
+++ b/src/ProfanityAnalyser.php
@@ -67,8 +67,11 @@ final class ProfanityAnalyser
                 foreach ($lines as $lineNumber => $line) {
                     $key = $lineNumber.'-'.$word;
                     if (preg_match('/\b'.preg_quote($word, '/').'\b/i', $line) === 1 && ! isset($foundProfanity[$key])) {
-                        $errors[] = new Error($file, $lineNumber + 1, $word);
-                        $foundProfanity[$key] = true;
+                        // Skip reporting profanity if the line contains the ignore annotation
+                        if (! str_contains($line, '@pest-ignore-profanity')) {
+                            $errors[] = new Error($file, $lineNumber + 1, $word);
+                            $foundProfanity[$key] = true;
+                        }
                     }
                 }
             }

--- a/tests/Fixtures/Ignore.php
+++ b/tests/Fixtures/Ignore.php
@@ -9,5 +9,5 @@ namespace Tests\Fixtures;
  */
 final class Ignore
 {
-    public const IGNORE = 'shitty'; //@pest-ignore-profanity
+    public const IGNORE = 'shitty'; // @pest-ignore-profanity
 }

--- a/tests/Fixtures/Ignore.php
+++ b/tests/Fixtures/Ignore.php
@@ -7,8 +7,7 @@ namespace Tests\Fixtures;
 /**
  * @internal
  */
-final class Language
+final class Ignore
 {
-    // møgso
-    // bollocks
+    public const IGNORE = 'shitty'; //@pest-ignore-profanity
 }

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -107,6 +107,22 @@ test('config files return lowercase and unique values', function () {
         ->toBeOrdered();
 });
 
+test('ignore lines', function () {
+    $output = new BufferedOutput;
+    $plugin = new class($output) extends Plugin
+    {
+        public function exit(int $code): never
+        {
+            throw new Exception($code);
+        }
+    };
+
+    expect(fn () => $plugin->handleOriginalArguments(['--profanity']))->toThrow(Exception::class, 1)
+        ->and($output->fetch())->not->toContain(
+            '.. pr12(shitty)'
+        );
+});
+
 test('json output', function () {
     $output = new BufferedOutput;
     $plugin = new class($output) extends Plugin


### PR DESCRIPTION
This PR adds a way to be able to exclude certain lines from being picked up in the Profanity check.

By adding `// @pest-ignore-profanity`, the line gets skipped. 

Useful if there's a certain line or 2 that for whatever reason, needs to have profanity. 