### PR TITLE
Set Default Language to EN

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -105,7 +105,8 @@ class Plugin implements HandlesOriginalArguments
             }
 
             if (str_starts_with($argument, '--language=')) {
-                $this->language = substr($argument, strlen('--language='));
+                $languageValue = substr($argument, strlen('--language='));
+                $this->language = explode(',', $languageValue);
                 unset($arguments[$key]);
             }
 

--- a/src/ProfanityAnalyser.php
+++ b/src/ProfanityAnalyser.php
@@ -34,7 +34,7 @@ final class ProfanityAnalyser
         $profanitiesFiles = array_diff($profanitiesFiles, ['.', '..']);
 
         if ($language) {
-            $languages = is_string($language) ? [$language] : $language;
+            $languages = is_array($language) ? $language : [$language];
 
             foreach ($languages as $lang) {
                 $specificLanguage = "$profanitiesDir/$lang.php";
@@ -46,12 +46,10 @@ final class ProfanityAnalyser
                 }
             }
         } else {
-            foreach ($profanitiesFiles as $profanitiesFile) {
-                $words = array_merge(
-                    $words,
-                    include "$profanitiesDir/$profanitiesFile"
-                );
-            }
+            $words = array_merge(
+                $words,
+                include "$profanitiesDir/en.php"
+            );
         }
 
         $words = array_merge($words, $includingWords);

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -20,8 +20,10 @@ test('output', function () {
             ' pr12(shit), pr14(shit), pr16(shit), pr18(shit)',
             '.. pr12(arse)',
             '.. pr12(fuck)',
-            '.. pr12(møgso), pr13(bollocks)',
             '.. pr12(nobhead)',
+        )
+        ->and($output->fetch())->not->toContain(
+            '.. pr12(møgso)',
         );
 });
 
@@ -41,11 +43,11 @@ test('compact output', function () {
             ' pr12(shit), pr14(shit), pr16(shit), pr18(shit)',
             '.. pr12(arse)',
             '.. pr12(fuck)',
-            '.. pr12(møgso), pr13(bollocks)',
             '.. pr12(nobhead)',
         )
         ->and($output->fetch())->not->toContain(
-            '.. OK'
+            '.. OK',
+            '.. pr12(møgso)'
         );
 });
 
@@ -97,6 +99,22 @@ test('specific language', function () {
         )
         ->and($output->fetch())->not->toContain(
             '.. pr13(bollocks)'
+        );
+});
+
+test('multiple languages', function () {
+    $output = new BufferedOutput;
+    $plugin = new class($output) extends Plugin
+    {
+        public function exit(int $code): never
+        {
+            throw new Exception($code);
+        }
+    };
+
+    expect(fn () => $plugin->handleOriginalArguments(['--profanity', '--language=en,da']))->toThrow(Exception::class, 1)
+        ->and($output->fetch())->toContain(
+            'pr12(møgso), pr13(bollocks)'
         );
 });
 


### PR DESCRIPTION
Chatting with Nuno last night and we decided on making `en` the default language.

You can already specify the language using the `--language` option. This PR tweaks that to accept multiple languages if needed e.g. `--language=en,da`. 